### PR TITLE
Improve Azure OpenAI helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*.parquet

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # agent_talk_data
-The repository is contain the code for talk with data in database, parquet or csv. You can retrieve data, analysis, do machine learning and create visualization from this and more important is reasoning on the data.
+
+`agent_talk_data` provides building blocks for an AI agent that can query
+multiple data sources, perform analysis, run simple machine learning models and
+visualise results. It also includes reasoning helpers that can be wired to a
+large language model service such as OpenAI or Azure OpenAI.
+
+## Features
+
+- Query PostgreSQL or MySQL via SQLAlchemy
+- Read `.parquet` files with pandas
+- Join data from different sources
+- Compute statistics and correlations
+- Run linear/logistic regression and k-means clustering
+- Plot using Plotly
+- Simple reasoning layer with pluggable LLM backend and basic tool calling
+
+## Example
+
+```bash
+pip install pandas sqlalchemy scikit-learn plotly openai
+python examples/demo.py
+```
+
+See `examples/demo.py` for a short demonstration. The reasoning example works
+with Azure OpenAI by setting `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_KEY` and
+`AZURE_OPENAI_DEPLOYMENT` environment variables. The helper uses `from openai
+import AzureOpenAI` when available and falls back to the legacy client
+configuration.
+
+## Development
+
+A list of open tasks can be found in `TODO.md`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# TODO
+
+- [ ] Implement comprehensive unit tests
+- [ ] Build CLI for querying data sources
+- [ ] Integrate advanced LLM reasoning similar to PandasAI or VannaAI
+- [ ] Expand tool-based agent with Azure OpenAI support
+- [ ] Add support for more visualization types
+- [ ] Provide docker setup for databases
+- [ ] Write detailed documentation

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,0 +1,47 @@
+"""Example usage of the agent package."""
+from agent import (
+    DataSource,
+    join_dataframes,
+    describe,
+    regression,
+    scatter,
+    Tool,
+    ToolReasoningAgent,
+    azure_openai_llm,
+)
+
+
+def main():
+    # Example using parquet file
+    sales = DataSource.read_parquet("data/sales.parquet")
+
+    print(describe(sales))
+
+    model, mse = regression(sales, target="revenue")
+    print("Regression MSE:", mse)
+
+    scatter(sales, x="date", y="revenue")
+
+    # Tool reasoning agent using Azure OpenAI
+    tools = {
+        "describe": Tool(
+            name="describe",
+            func=lambda: describe(sales),
+            description="Show dataframe statistics",
+        ),
+        "plot": Tool(
+            name="plot",
+            func=lambda: scatter(sales, x="date", y="revenue"),
+            description="Plot revenue over time",
+        ),
+    }
+    agent = ToolReasoningAgent(azure_openai_llm, tools)
+    try:
+        answer = agent.ask("Show me the stats")
+        print(answer)
+    except RuntimeError as err:
+        print(err)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,31 @@
+"""High level API for the agent package."""
+
+from .datasource import DataSource, join_dataframes
+from .analysis import describe, correlation
+from .ml import regression, classification, clustering
+from .visualization import scatter, line, bar
+from .reasoning import (
+    ReasoningAgent,
+    Tool,
+    ToolReasoningAgent,
+    openai_llm,
+    azure_openai_llm,
+)
+
+__all__ = [
+    "DataSource",
+    "join_dataframes",
+    "describe",
+    "correlation",
+    "regression",
+    "classification",
+    "clustering",
+    "scatter",
+    "line",
+    "bar",
+    "ReasoningAgent",
+    "Tool",
+    "ToolReasoningAgent",
+    "openai_llm",
+    "azure_openai_llm",
+]

--- a/src/agent/analysis.py
+++ b/src/agent/analysis.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+def describe(df: pd.DataFrame) -> pd.DataFrame:
+    """Return basic statistics for the dataframe."""
+    return df.describe(include='all')
+
+
+def correlation(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute correlation matrix."""
+    return df.corr(numeric_only=True)

--- a/src/agent/datasource.py
+++ b/src/agent/datasource.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from sqlalchemy import create_engine
+
+
+class DataSource:
+    """Handles connections to PostgreSQL, MySQL and reading parquet files."""
+
+    def __init__(self, connection_string: str | None = None, type_: str | None = None):
+        """Initialize the data source.
+
+        Parameters
+        ----------
+        connection_string : str, optional
+            SQLAlchemy connection string for the database.
+        type_ : str, optional
+            Type of the database. Supported values: "postgresql", "mysql".
+        """
+        self.type = type_
+        self.connection_string = connection_string
+        self._engine = None
+        if connection_string and type_:
+            self._engine = create_engine(connection_string)
+
+    def query(self, sql: str) -> pd.DataFrame:
+        """Run a SQL query and return a dataframe."""
+        if not self._engine:
+            raise ValueError("No database connection configured")
+        return pd.read_sql(sql, self._engine)
+
+    @staticmethod
+    def read_parquet(path: str) -> pd.DataFrame:
+        """Read a Parquet file to a dataframe."""
+        return pd.read_parquet(path)
+
+
+def join_dataframes(*dfs: pd.DataFrame, on: str, how: str = "inner") -> pd.DataFrame:
+    """Join multiple dataframes on a column."""
+    if not dfs:
+        raise ValueError("No dataframes provided")
+    result = dfs[0]
+    for df in dfs[1:]:
+        result = result.merge(df, on=on, how=how)
+    return result

--- a/src/agent/ml.py
+++ b/src/agent/ml.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.cluster import KMeans
+from sklearn.metrics import accuracy_score, mean_squared_error
+
+
+def regression(df: pd.DataFrame, target: str):
+    """Perform a simple linear regression."""
+    X = df.drop(columns=[target])
+    y = df[target]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    mse = mean_squared_error(y_test, preds)
+    return model, mse
+
+
+def classification(df: pd.DataFrame, target: str):
+    """Perform a logistic regression classification."""
+    X = df.drop(columns=[target])
+    y = df[target]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    return model, acc
+
+
+def clustering(df: pd.DataFrame, k: int):
+    """KMeans clustering."""
+    model = KMeans(n_clusters=k, n_init=10)
+    model.fit(df)
+    return model, model.labels_

--- a/src/agent/reasoning.py
+++ b/src/agent/reasoning.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Any, Dict
+
+
+@dataclass
+class ReasoningAgent:
+    """Very simple reasoning agent that can use an LLM backend."""
+
+    llm_func: Callable[[str], str]
+
+    def ask(self, question: str) -> str:
+        """Generate an answer using the provided llm function."""
+        return self.llm_func(question)
+
+
+@dataclass
+class Tool:
+    """Represents a callable tool for the agent."""
+
+    name: str
+    func: Callable[..., Any]
+    description: str = ""
+
+
+@dataclass
+class ToolReasoningAgent:
+    """Reasoning agent that can call tools suggested by the LLM."""
+
+    llm_func: Callable[[str], str]
+    tools: Dict[str, Tool]
+
+    def ask(self, question: str) -> Any:
+        """Ask a question and execute the tool chosen by the LLM."""
+        tool_desc = "\n".join(
+            f"{name}: {tool.description}" for name, tool in self.tools.items()
+        )
+        prompt = (
+            "You are a data assistant. Available tools:\n" + tool_desc + "\n" +
+            f"Question: {question}\n" +
+            "Respond with JSON {\"tool\": \"name\", \"args\": {...}}"
+        )
+        response = self.llm_func(prompt)
+        try:
+            import json
+
+            data = json.loads(response)
+            tool_name = data.get("tool")
+            args = data.get("args", {})
+            if tool_name not in self.tools:
+                raise ValueError(f"Unknown tool {tool_name}")
+            return self.tools[tool_name].func(**args)
+        except Exception as exc:  # pragma: no cover - response parsing
+            raise RuntimeError(
+                f"Could not use tool from response: {response}"
+            ) from exc
+
+
+# Example usage with OpenAI (requires openai package and API key)
+try:
+    import openai
+
+    def openai_llm(prompt: str) -> str:
+        completion = openai.Completion.create(engine="text-davinci-003", prompt=prompt, max_tokens=200)
+        return completion.choices[0].text.strip()
+except Exception:  # pragma: no cover - openai not installed during tests
+    def openai_llm(prompt: str) -> str:
+        raise RuntimeError("OpenAI is not available")
+
+
+# Azure OpenAI helper
+try:  # OpenAI >= 1.0 style client
+    from openai import AzureOpenAI  # type: ignore
+    import os
+
+    _azure_client = AzureOpenAI(
+        api_version="2023-07-01-preview",
+        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", ""),
+        api_key=os.getenv("AZURE_OPENAI_KEY", ""),
+    )
+
+    def azure_openai_llm(prompt: str) -> str:
+        """Call an Azure OpenAI deployment (defaults to o3-mini)."""
+        deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT", "o3-mini")
+        completion = _azure_client.chat.completions.create(
+            model=deployment,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200,
+        )
+        return completion.choices[0].message.content.strip()
+except Exception:
+    try:  # fallback to legacy client
+        import openai  # type: ignore
+        import os
+
+        def azure_openai_llm(prompt: str) -> str:
+            openai.api_type = "azure"
+            openai.api_version = "2023-07-01-preview"
+            openai.api_base = os.getenv("AZURE_OPENAI_ENDPOINT", "")
+            openai.api_key = os.getenv("AZURE_OPENAI_KEY", "")
+            deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT", "o3-mini")
+            completion = openai.ChatCompletion.create(
+                deployment_id=deployment,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=200,
+            )
+            return completion.choices[0].message["content"].strip()
+    except Exception:  # pragma: no cover - openai not installed
+        def azure_openai_llm(prompt: str) -> str:
+            raise RuntimeError("Azure OpenAI is not available")

--- a/src/agent/visualization.py
+++ b/src/agent/visualization.py
@@ -1,0 +1,20 @@
+import plotly.express as px
+import pandas as pd
+
+
+def scatter(df: pd.DataFrame, x: str, y: str, color: str | None = None):
+    fig = px.scatter(df, x=x, y=y, color=color)
+    fig.show()
+    return fig
+
+
+def line(df: pd.DataFrame, x: str, y: str, color: str | None = None):
+    fig = px.line(df, x=x, y=y, color=color)
+    fig.show()
+    return fig
+
+
+def bar(df: pd.DataFrame, x: str, y: str, color: str | None = None):
+    fig = px.bar(df, x=x, y=y, color=color)
+    fig.show()
+    return fig


### PR DESCRIPTION
## Summary
- add `AzureOpenAI` client usage with fallback to legacy configuration
- mention new helper details in README

## Testing
- `python -m py_compile $(find src -name '*.py') examples/demo.py`


------
https://chatgpt.com/codex/tasks/task_b_684ac24f2fb88328ba0a401a54e56aef